### PR TITLE
Add required CNCF website footer text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -524,6 +524,29 @@ function App() {
             <Outlet />
           )}
         </main>
+
+        {/* Footer */}
+        <footer className="bg-gray-900 text-gray-300 py-8 mt-auto">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center">
+              <p className="text-sm">
+                Copyright K8sGPT a Series of LF Projects, LLC.
+              </p>
+              <p className="text-sm mt-2">
+                For website terms of use, trademark policy and other project policies please see{' '}
+                <a 
+                  href="https://lfprojects.org/policies/" 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-indigo-400 hover:text-indigo-300 underline"
+                >
+                  lfprojects.org/policies
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </footer>
       </div>
     </>
   );


### PR DESCRIPTION
## 📑 Description
This adds the footer mentioned in the https://github.com/cncf/sandbox/issues/148 and [website guidelines](https://github.com/cncf/foundation/blob/main/policies-guidance/website-guidelines.md).

## ℹ Additional Information
<img width="1320" height="511" alt="image" src="https://github.com/user-attachments/assets/1b5cec5d-48f4-4d13-8344-671f1d931f68" />

