### PR TITLE
fix(docs): prevent code block overflow on installation page

### DIFF
--- a/src/pages/docs/getting-started/Installation.tsx
+++ b/src/pages/docs/getting-started/Installation.tsx
@@ -148,6 +148,32 @@ Check out our [configuration guide](/docs/getting-started/configuration) to get 
                 </div>
               );
             },
+            pre: ({node, children, ...props}) => (
+              <pre
+                className="my-4 max-w-full overflow-x-auto rounded-lg bg-gray-100 p-4 text-sm"
+                {...props}
+              >
+                {children}
+              </pre>
+            ),
+            code: ({node, className, children, ...props}) => {
+              const isInline = !className;
+              if (isInline) {
+                return (
+                  <code
+                    className="rounded bg-gray-100 px-2 py-1 break-words"
+                    {...props}
+                  >
+                    {children}
+                  </code>
+                );
+              }
+              return (
+                <code className={`${className ?? ''} whitespace-pre`} {...props}>
+                  {children}
+                </code>
+              );
+            },
           }}
         >
           {markdownContent.replace('# Installation Methods\n\n', '')}


### PR DESCRIPTION
## Problem

The installation page (`/docs/getting-started/installation`) had a horizontal overflow issue: long install URLs and commands pushed the page wider than the viewport.

The root cause is that the page relies on `prose-pre`/`prose-code` Tailwind classes from `@tailwindcss/typography`, but that plugin is not installed (`plugins: []` in `tailwind.config.js`). As a result, code blocks rendered completely unstyled with no horizontal scrolling, so long lines expanded the page.

## Fix

Added explicit `pre`/`code` renderers to the `ReactMarkdown` instance in `Installation.tsx`, using the same light code-block style already used across the rest of the docs (e.g. the CLI reference page): `bg-gray-100 p-4 rounded-lg overflow-x-auto`.

Long lines now scroll inside the code block instead of expanding the page.

Before
<img width="1560" height="956" alt="image" src="https://github.com/user-attachments/assets/a3db3f5e-58f2-4ebb-95eb-09334dd5232e" />

After
<img width="1558" height="961" alt="image" src="https://github.com/user-attachments/assets/5358ae40-6d0b-4cb6-884f-0aadceef83c6" />


## Verification

- Desktop (1280px) and mobile (375px): page no longer overflows horizontally.
- Long content scrolls inside the code block as expected.
- Code blocks now match the styling of the CLI reference page for visual consistency.